### PR TITLE
Remove trailing returns from pkg -l output

### DIFF
--- a/completions/pkg
+++ b/completions/pkg
@@ -84,7 +84,7 @@ _pkg()
     local cur prev words cword
     _init_completion || return
 
-    readarray command_list < <(pkg -l)
+    readarray -t command_list < <(pkg -l)
 
     local -A alias_map
     local _alias _command


### PR DESCRIPTION
Fixes #5 